### PR TITLE
Changed getColorArgs() to avoid creating new table each call

### DIFF
--- a/vivid.lua
+++ b/vivid.lua
@@ -34,13 +34,11 @@ local math_rad = math.rad
 local math_abs = math.abs
 
 -- Helper function to mimic the LOVE API, allows you to pass a table or four arguments
-local function getColorArgs(...)
-  local t = {...}
-  if type(t[1]) == "table" then
-    return unpack(t[1])
-  else
-    return unpack(t)
+local function getColorArgs(first, ...)
+  if type(first) == "table" then
+    return unpack(first)
   end
+  return first, ...
 end
 
 --RGB to `colorspace`


### PR DESCRIPTION
In cases where the conversion functions are called many times per frame the cost of creating a table each time may be noticeably decremental to performance.
